### PR TITLE
Add service account for query history (telemetry) and bucket

### DIFF
--- a/big-query-and-gcs-backend/.gitignore
+++ b/big-query-and-gcs-backend/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/big-query-and-gcs-backend/.terraform.lock.hcl
+++ b/big-query-and-gcs-backend/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.49.0"
+  constraints = "4.49.0"
+  hashes = [
+    "h1:XFuRaDeIxzlBWs8c4tseZR2D2sbFUQUY732ljVa61aM=",
+    "zh:06759e2760d4c462d1c29ffae91f14be05b478570804c38fdac343bf4e40362e",
+    "zh:3728742e19d8df05954c48d09e0ed88943f940c18d200f0e872028d576567d63",
+    "zh:5678d0d22e7345adaa0f780e8160a828fd7a6d11fc5be8fb57f079214b9bc99a",
+    "zh:5e855410c1ccbe3e6d75d1d0fb7dde8aef79b45b885cfa3204a1af157a5dc39f",
+    "zh:64338003cc5b8ab93a504ae8cdd05d1c60deef411b2ae357ae5f8af8b7592bdf",
+    "zh:9fa9c1ae81faf8158f46845e92871fa12900ff04620479f0162619383cf737a4",
+    "zh:b73ee8222bcb9fbd73ca4c0c56664d57467c9371bc7bce61988e958771d8e697",
+    "zh:c94cfec61659cd20921acb1dd9b2694f88f14fbb4191b8c55700ccba26464828",
+    "zh:d3231ad73401d735cf9323347a277d44028038ec5cde29f2ca77e3be1ea9e68a",
+    "zh:d4a15dee6a2d5b1cb73db94d6b8b16d29f7a7295b2a6ffdc8cb50caa968f763c",
+    "zh:e7f8d35a982986cef712da221bf5f1e309397559c397a11758c30c45919188b0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/big-query-and-gcs-backend/README.md
+++ b/big-query-and-gcs-backend/README.md
@@ -15,18 +15,21 @@
         terraform init
 
 3. Create a new folder in your organization through GCP Console, and note the ID of the folder for the next step, e.g. `GCP_FOLDER_ID=380380380380`.
-4. Set two additional arguments:
-    - `GCP_BILLING_ID`: ID of billing account to which you wish to add projects created as backend for *Keboola Connection*. For more
+4. Create `terraform.tfvars` file:
+```
+folder_id=""
+billing_account_id="01C438-814D25-220303"
+backend_prefix="dev-gcp-us-bq"
+gcp_region="us"
+```
+    - `folder_id`: ID of billing account to which you wish to add projects created as backend for *Keboola Connection*. For more
       information what is billing account, please visit [this link](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
-    - `BACKEND_PREFIX`: Prefix to be given to the folder and the main backend project. It is used to differentiate between existing projects and the new backend, or multiple backends in one organization due to the strictness of GCP and project names. The length of the project name is short for GCP, so choose something like initials, i.e. `rb`
-    - `GCP_REGION`: Location of GCS File Storage bucket. You can choose single region (e.g. `europe-west3`) or multi-region (e.g. `us`). See available [locations](https://cloud.google.com/storage/docs/locations#available-locations)
+    - `backend_prefix`: Prefix to be given to the folder and the main backend project. It is used to differentiate between existing projects and the new backend, or multiple backends in one organization due to the strictness of GCP and project names. The length of the project name is short for GCP, so choose something like initials, i.e. `rb`
+    - `gcp_region`: Location of GCS File Storage bucket. You can choose single region (e.g. `europe-west3`) or multi-region (e.g. `us`). See available [locations](https://cloud.google.com/storage/docs/locations#available-locations)
 5. Run:
-
-        terraform apply \
-          -var folder_id=$GCP_FOLDER_ID \
-          -var billing_account_id=$GCP_BILLING_ID \
-          -var backend_prefix=$BACKEND_PREFIX \
-          -var gcp_region=$GCP_REGION
+```
+        terraform apply
+```
 
 You'll get two outputs from after applying the Terraform:
 

--- a/big-query-and-gcs-backend/main.tf
+++ b/big-query-and-gcs-backend/main.tf
@@ -32,6 +32,7 @@ locals {
   service_project_name        = "main-${var.backend_prefix}-bq-driver"
   service_project_id          = "${var.backend_prefix}-bq-driver"
   service_account_id          = "${var.backend_prefix}-main-service-acc"
+  service_query_account_id    = "${var.backend_prefix}-query-history-acc"
 }
 
 variable "services" {
@@ -141,4 +142,21 @@ resource "google_project_iam_member" "prj_service_acc_objAdm" {
   project = google_project.service_project_in_a_folder.project_id
   role    = "roles/storage.objectAdmin"
   member  = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+# Service account for query history (telemetry)
+resource "google_service_account" "service_account_query_history" {
+  account_id  = local.service_query_account_id
+  description = "Service account for query history"
+  project     = google_project.service_project_in_a_folder.project_id
+}
+
+resource "google_folder_iam_member" "folder_service_acc_query_history_role" {
+  folder = data.google_folder.existing_folder.name
+  role   = "roles/bigquery.resourceViewer"
+  member = "serviceAccount:${google_service_account.service_account_query_history.email}"
+}
+
+output "service_account_query_history_id" {
+  value = google_service_account.service_account_query_history.id
 }

--- a/big-query-and-gcs-backend/main.tf
+++ b/big-query-and-gcs-backend/main.tf
@@ -36,7 +36,7 @@ locals {
 }
 
 variable "services" {
-  type = list(any)
+  type    = list(any)
   default = [
     "cloudresourcemanager.googleapis.com",
     "serviceusage.googleapis.com",
@@ -157,6 +157,41 @@ resource "google_folder_iam_member" "folder_service_acc_query_history_role" {
   member = "serviceAccount:${google_service_account.service_account_query_history.email}"
 }
 
+resource "google_project_iam_member" "query_history_bq_data_editor" {
+  project = google_project.service_project_in_a_folder.project_id
+  role    = "roles/bigquery.dataEditor"
+  member = "serviceAccount:${google_service_account.service_account_query_history.email}"
+}
+
+resource "google_project_iam_member" "query_history_bq_job_user" {
+  project = google_project.service_project_in_a_folder.project_id
+  role    = "roles/bigquery.jobUser"
+  member = "serviceAccount:${google_service_account.service_account_query_history.email}"
+}
+
+resource "google_storage_bucket" "query_history_extractor" {
+  name                        = "${var.backend_prefix}-q-history"
+  project                     = google_project.service_project_in_a_folder.project_id
+  location                    = var.gcp_region
+  storage_class               = "STANDARD"
+  force_destroy               = true
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+  versioning {
+    enabled = false
+  }
+}
+
+resource "google_storage_bucket_iam_member" "query_history_extractor" {
+  bucket = google_storage_bucket.query_history_extractor.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.service_account_query_history.email}"
+}
+
 output "service_account_query_history_id" {
   value = google_service_account.service_account_query_history.id
+}
+
+output "query_history_bucket_id" {
+  value = google_storage_bucket.query_history_extractor.name
 }

--- a/big-query-and-gcs-backend/main.tf
+++ b/big-query-and-gcs-backend/main.tf
@@ -32,7 +32,7 @@ locals {
   service_project_name        = "main-${var.backend_prefix}-bq-driver"
   service_project_id          = "${var.backend_prefix}-bq-driver"
   service_account_id          = "${var.backend_prefix}-main-service-acc"
-  service_query_account_id    = "${var.backend_prefix}-query-history-acc"
+  service_query_account_id    = substr("${var.backend_prefix}-query-history-acc", 0, 30)
 }
 
 variable "services" {


### PR DESCRIPTION
Part of https://keboola.atlassian.net/browse/ST-2211

Potřebujeme v rámci telemetry umět sbírat query history cross všechny BQ pro stack, proto je potřeba vytvořit v BQ service projektu SA, který bude mít nad folderem kam se vytváří BQ projekty `roles/bigquery.resourceViewer`.

Nahodil jsem si prázdný folder `eddycek-ST-2211` a z main branch spustil TF apply, po nasazení vidím že na folder pro tuto roli mají oprávnění pouze tyto SA

![Snímek obrazovky 2024-09-17 v 18 27 18](https://github.com/user-attachments/assets/c8f6c258-bbfe-42b3-a93c-94fcdc123f59)

Po přidání požadovaného SA (viz změna v tomto PR) jsem spustil apply znovu, nyní vidím že nový SA `eddycek-query-history-acc@eddycek-bq-driver.iam.gserviceaccount.com` má potřebné oprávnění nad folderem.

![Snímek obrazovky 2024-09-17 v 18 41 54](https://github.com/user-attachments/assets/a6431067-8425-41a8-bb35-fd263c45b66b)

![Snímek obrazovky 2024-09-17 v 18 42 16](https://github.com/user-attachments/assets/3088b228-fe64-4d20-8a64-efb35532cd5a)

Toto budeme potřebovat jen tam kde bude BQ vytvořeno ze strany Kebooly, takže primárně v případě multitenancy stacku. Pro GCP US a EU tento SA vytvořím ručně.

Jak to bude nastavené v telemetry se rísuje zde https://github.com/keboola/telemetry-raw-projects/pull/190
